### PR TITLE
카카오 API 카테고리 장소 검색으로 약국 찾기

### DIFF
--- a/src/main/java/com/springstudy/projectmap/api/dto/DocumentDto.java
+++ b/src/main/java/com/springstudy/projectmap/api/dto/DocumentDto.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DocumentDto {
 
+    @JsonProperty("place_name")
+    private String placeName;
+
     @JsonProperty("address_name")
     private String addressName;
 
@@ -20,4 +23,7 @@ public class DocumentDto {
 
     @JsonProperty("x")
     private double longitude;
+
+    @JsonProperty("distance")
+    private double distance;
 }

--- a/src/main/java/com/springstudy/projectmap/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/springstudy/projectmap/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,41 @@
+package com.springstudy.projectmap.api.service;
+
+import com.springstudy.projectmap.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9"; // 약국 카테고리
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+
+        URI uri = kakaoUriBuilderService.buildUriByCategorySearch(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+
+}

--- a/src/main/java/com/springstudy/projectmap/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/springstudy/projectmap/api/service/KakaoUriBuilderService.java
@@ -12,6 +12,8 @@ public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
+
     public URI buildUriByAddressSearch(String address) {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
@@ -19,6 +21,23 @@ public class KakaoUriBuilderService {
 
         URI uri = uriBuilder.build().encode().toUri();
         log.info("[KakaoUriBuilderService buildUriByAddressSearch] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+    public URI buildUriByCategorySearch(double latitude, double longitude, double radius, String category) {
+
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        uriBuilder.queryParam("category_group_code", category);
+        uriBuilder.queryParam("x", latitude);
+        uriBuilder.queryParam("y", longitude);
+        uriBuilder.queryParam("radius", meterRadius);
+        uriBuilder.queryParam("sort", "distance");
+
+        URI uri = uriBuilder.build().encode().toUri();
+
+        log.info("[KakaoUriBuilderService buildUriByCategorySearch] uri: {}", uri);
 
         return uri;
     }

--- a/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
+++ b/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
@@ -1,6 +1,7 @@
 package com.springstudy.projectmap.direction.service;
 
 import com.springstudy.projectmap.api.dto.DocumentDto;
+import com.springstudy.projectmap.api.service.KakaoCategorySearchService;
 import com.springstudy.projectmap.direction.entity.Direction;
 import com.springstudy.projectmap.direction.repository.DirectionRepository;
 import com.springstudy.projectmap.pharmacy.service.PharmacySearchService;
@@ -58,6 +59,31 @@ public class DirectionService {
                                 .build())
                 .filter(direction -> direction.getDistance() <= RADIUS_KM)
                 .sorted(Comparator.comparing(Direction::getDistance))
+                .limit(MAX_SEARCH_COUNT)
+                .collect(Collectors.toList());
+
+    }
+
+    // pharmacy search by category kakao api
+    public List<Direction> buildDirectionListByCategoryApi(DocumentDto inputDocumentDto) {
+
+        if (Objects.isNull(inputDocumentDto))
+            return Collections.emptyList();
+
+        return kakaoCategorySearchService
+                .requestPharmacyCategorySearch(inputDocumentDto.getLatitude(), inputDocumentDto.getLongitude(), RADIUS_KM)
+                .getDocumentList()
+                .stream().map(resultDocumentDto ->
+                        Direction.builder()
+                                .inputAddress(inputDocumentDto.getAddressName())
+                                .inputLatitude(inputDocumentDto.getLatitude())
+                                .inputLongitude(inputDocumentDto.getLongitude())
+                                .targetPharmacyName(resultDocumentDto.getPlaceName())
+                                .targetAddress(resultDocumentDto.getAddressName())
+                                .targetLatitude(resultDocumentDto.getLatitude())
+                                .targetLongitude(resultDocumentDto.getLongitude())
+                                .distance(resultDocumentDto.getDistance() * 0.001) // km 단위
+                                .build())
                 .limit(MAX_SEARCH_COUNT)
                 .collect(Collectors.toList());
 

--- a/src/test/groovy/com/springstudy/projectmap/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/springstudy/projectmap/direction/service/DirectionServiceTest.groovy
@@ -1,6 +1,8 @@
 package com.springstudy.projectmap.direction.service
 
 import com.springstudy.projectmap.api.dto.DocumentDto
+import com.springstudy.projectmap.api.service.KakaoCategorySearchService
+import com.springstudy.projectmap.direction.repository.DirectionRepository
 import com.springstudy.projectmap.pharmacy.dto.PharmacyDto
 import com.springstudy.projectmap.pharmacy.service.PharmacySearchService
 import spock.lang.Specification
@@ -8,8 +10,10 @@ import spock.lang.Specification
 class DirectionServiceTest extends Specification {
 
     private PharmacySearchService pharmacySearchService = Mock()
+    private DirectionRepository directionRepository = Mock()
+    private KakaoCategorySearchService kakaoCategorySearchService = Mock()
 
-    private DirectionService directionService = new DirectionService(pharmacySearchService)
+    private DirectionService directionService = new DirectionService(pharmacySearchService, directionRepository, kakaoCategorySearchService)
 
     private List<PharmacyDto> pharmacyList
 


### PR DESCRIPTION
공공기관에서 제공받은 데이터로 약국을 찾던 방식에서
실시간 업데이트와 확장 가능성이 있는 카카오 API 카테고리 장소 검색으로
근처 약국 찾는 방식으로 변경.