### PR TITLE
길안내 및 로드뷰 URL 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // https://github.com/seruco/base62
+    implementation 'io.seruco.encoding:base62:0.1.3'
+
     // handlebars
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.4'
 

--- a/src/main/java/com/springstudy/projectmap/direction/controller/DirectionController.java
+++ b/src/main/java/com/springstudy/projectmap/direction/controller/DirectionController.java
@@ -15,17 +15,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class DirectionController {
 
     private final DirectionService directionService;
-    private static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/map/";
 
     @GetMapping("/dir/{encodedId}")
     public String searchDirection(@PathVariable("encodedId") String encodedId) {
-        Direction resultDirection = directionService.findById(encodedId);
 
-        String params = String.join(",", resultDirection.getTargetPharmacyName(),
-                String.valueOf(resultDirection.getTargetLatitude()), String.valueOf(resultDirection.getTargetLongitude()));
+        String result = directionService.findDirectionUrlById(encodedId);
 
-        String result = UriComponentsBuilder.fromHttpUrl(DIRECTION_BASE_URL + params)
-                .toUriString();
+        log.info("[DirectionController searchDirection] direction url: {}", result);
 
         return "redirect:" + result;
     }

--- a/src/main/java/com/springstudy/projectmap/direction/controller/DirectionController.java
+++ b/src/main/java/com/springstudy/projectmap/direction/controller/DirectionController.java
@@ -1,0 +1,32 @@
+package com.springstudy.projectmap.direction.controller;
+
+import com.springstudy.projectmap.direction.entity.Direction;
+import com.springstudy.projectmap.direction.service.DirectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Controller
+@Slf4j
+@RequiredArgsConstructor
+public class DirectionController {
+
+    private final DirectionService directionService;
+    private static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/map/";
+
+    @GetMapping("/dir/{encodedId}")
+    public String searchDirection(@PathVariable("encodedId") String encodedId) {
+        Direction resultDirection = directionService.findById(encodedId);
+
+        String params = String.join(",", resultDirection.getTargetPharmacyName(),
+                String.valueOf(resultDirection.getTargetLatitude()), String.valueOf(resultDirection.getTargetLongitude()));
+
+        String result = UriComponentsBuilder.fromHttpUrl(DIRECTION_BASE_URL + params)
+                .toUriString();
+
+        return "redirect:" + result;
+    }
+}

--- a/src/main/java/com/springstudy/projectmap/direction/service/Base62Service.java
+++ b/src/main/java/com/springstudy/projectmap/direction/service/Base62Service.java
@@ -1,0 +1,23 @@
+package com.springstudy.projectmap.direction.service;
+
+import io.seruco.encoding.base62.Base62;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Base62Service {
+
+    private static final Base62 base62Instance = Base62.createInstance();
+
+    public String encodeDirectionId(Long directionId) {
+        return new String(base62Instance.encode(String.valueOf(directionId).getBytes()));
+    }
+
+    public Long decodeDirectionId(String encodedDirectionId) {
+        String resultDirectionId = new String(base62Instance.decode(encodedDirectionId.getBytes()));
+        return Long.valueOf(resultDirectionId);
+    }
+}

--- a/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
+++ b/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -24,6 +25,7 @@ public class DirectionService {
 
     private static final int MAX_SEARCH_COUNT = 3; // 약국 최대 검색 갯수
     private static final double RADIUS_KM = 10.0; // 반경 10 km
+    private static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/map/";
 
     private final PharmacySearchService pharmacySearchService;
     private final DirectionRepository directionRepository;
@@ -38,9 +40,18 @@ public class DirectionService {
         return directionRepository.saveAll(directionList);
     }
 
-    public Direction findById(String encodedId) {
+    public String findDirectionUrlById(String encodedId) {
         Long decodedId = base62Service.decodeDirectionId(encodedId);
-        return directionRepository.findById(decodedId).orElse(null);
+        Direction direction = directionRepository.findById(decodedId).orElse(null);
+
+
+        String params = String.join(",", direction.getTargetPharmacyName(),
+                String.valueOf(direction.getTargetLatitude()), String.valueOf(direction.getTargetLongitude()));
+
+        String result = UriComponentsBuilder.fromHttpUrl(DIRECTION_BASE_URL + params)
+                .toUriString();
+
+        return result;
     }
 
     public List<Direction> buildDirectionList(DocumentDto documentDto) {

--- a/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
+++ b/src/main/java/com/springstudy/projectmap/direction/service/DirectionService.java
@@ -28,6 +28,7 @@ public class DirectionService {
     private final PharmacySearchService pharmacySearchService;
     private final DirectionRepository directionRepository;
     private final KakaoCategorySearchService kakaoCategorySearchService;
+    private final Base62Service base62Service;
 
     @Transactional
     public List<Direction> saveAll(List<Direction> directionList) {
@@ -35,6 +36,11 @@ public class DirectionService {
             return Collections.emptyList();
 
         return directionRepository.saveAll(directionList);
+    }
+
+    public Direction findById(String encodedId) {
+        Long decodedId = base62Service.decodeDirectionId(encodedId);
+        return directionRepository.findById(decodedId).orElse(null);
     }
 
     public List<Direction> buildDirectionList(DocumentDto documentDto) {

--- a/src/main/java/com/springstudy/projectmap/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/springstudy/projectmap/pharmacy/service/PharmacyRecommendationService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +24,9 @@ public class PharmacyRecommendationService {
 
     private final KakaoAddressSearchService kakaoAddressSearchService;
     private final DirectionService directionService;
+
+    private static final String ROAD_VIEW_BASE_URL = "https://map.kakao.com/link/roadview/";
+    private static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/map/";
 
     public List<OutputDto> recommendPharmacyList(String address) {
 
@@ -48,11 +52,20 @@ public class PharmacyRecommendationService {
     }
 
     private OutputDto convertToOutputDto(Direction direction) {
+
+        String params = String.join(",", direction.getTargetPharmacyName(),
+                String.valueOf(direction.getTargetLatitude()), String.valueOf(direction.getTargetLongitude()));
+
+        String result = UriComponentsBuilder.fromHttpUrl(DIRECTION_BASE_URL + params)
+                .toUriString();
+
+        log.info("direction params: {}, url: {}", params, result);
+
         return OutputDto.builder()
                 .pharmacyName(direction.getTargetPharmacyName())
                 .pharmacyAddress(direction.getTargetAddress())
-                .directionUrl("todo")
-                .roadViewUrl("todo")
+                .directionUrl(result)
+                .roadViewUrl(ROAD_VIEW_BASE_URL + direction.getTargetLatitude() + "," + direction.getTargetLongitude())
                 .distance(String.format("%.2f km", direction.getDistance()))
                 .build();
     }

--- a/src/main/java/com/springstudy/projectmap/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/springstudy/projectmap/pharmacy/service/PharmacyRecommendationService.java
@@ -5,12 +5,13 @@ import com.springstudy.projectmap.api.dto.KakaoApiResponseDto;
 import com.springstudy.projectmap.api.service.KakaoAddressSearchService;
 import com.springstudy.projectmap.direction.dto.OutputDto;
 import com.springstudy.projectmap.direction.entity.Direction;
+import com.springstudy.projectmap.direction.service.Base62Service;
 import com.springstudy.projectmap.direction.service.DirectionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,9 +25,12 @@ public class PharmacyRecommendationService {
 
     private final KakaoAddressSearchService kakaoAddressSearchService;
     private final DirectionService directionService;
+    private final Base62Service base62Service;
 
     private static final String ROAD_VIEW_BASE_URL = "https://map.kakao.com/link/roadview/";
-    private static final String DIRECTION_BASE_URL = "https://map.kakao.com/link/map/";
+
+    @Value("${pharmacy.recommendation.base.url}")
+    private String baseUrl;
 
     public List<OutputDto> recommendPharmacyList(String address) {
 
@@ -53,18 +57,10 @@ public class PharmacyRecommendationService {
 
     private OutputDto convertToOutputDto(Direction direction) {
 
-        String params = String.join(",", direction.getTargetPharmacyName(),
-                String.valueOf(direction.getTargetLatitude()), String.valueOf(direction.getTargetLongitude()));
-
-        String result = UriComponentsBuilder.fromHttpUrl(DIRECTION_BASE_URL + params)
-                .toUriString();
-
-        log.info("direction params: {}, url: {}", params, result);
-
         return OutputDto.builder()
                 .pharmacyName(direction.getTargetPharmacyName())
                 .pharmacyAddress(direction.getTargetAddress())
-                .directionUrl(result)
+                .directionUrl(baseUrl + base62Service.encodeDirectionId(direction.getId()))
                 .roadViewUrl(ROAD_VIEW_BASE_URL + direction.getTargetLatitude() + "," + direction.getTargetLongitude())
                 .distance(String.format("%.2f km", direction.getDistance()))
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
       ddl-auto: validate
     show-sql: true
 
+pharmacy:
+  recommendation:
+    base:
+      url: http://localhost:8080/dir/
+
 ---
 spring:
   config:

--- a/src/main/resources/templates/output.hbs
+++ b/src/main/resources/templates/output.hbs
@@ -6,6 +6,17 @@
     <!--부트스트랩 css 추가-->
     <link rel="stylesheet" href="/css/lib/bootstrap.min.css">
 
+    <style>
+        .grid-image, .h2-title{
+            display: flex;
+            justify-content: center;
+        }
+        img {
+            margin: 0 0 5px;
+            width: 70%;
+            height: 550px;
+        }
+    </style>
 </head>
 <body>
 <div>

--- a/src/test/groovy/com/springstudy/projectmap/direction/controller/DirectionControllerTest.groovy
+++ b/src/test/groovy/com/springstudy/projectmap/direction/controller/DirectionControllerTest.groovy
@@ -1,0 +1,38 @@
+package com.springstudy.projectmap.direction.controller
+
+import com.springstudy.projectmap.direction.service.DirectionService
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class DirectionControllerTest extends Specification {
+
+    private MockMvc mockMvc
+    private DirectionService directionService = Mock()
+
+    def setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new DirectionController(directionService))
+                .build()
+    }
+
+    def "GET /dir/{encodedId}"() {
+        given:
+        String encodedId = "r"
+
+        String redirectURL = "https://map.kakao.com/link/map/pharmacy,38.11,128.11"
+
+        when:
+        directionService.findDirectionUrlById(encodedId) >> redirectURL
+        def result = mockMvc.perform(MockMvcRequestBuilders.get("/dir/{encodedId}", encodedId))
+
+        then:
+        result.andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(redirectURL))
+                .andDo(print())
+    }
+}

--- a/src/test/groovy/com/springstudy/projectmap/direction/service/Base62ServiceTest.groovy
+++ b/src/test/groovy/com/springstudy/projectmap/direction/service/Base62ServiceTest.groovy
@@ -1,0 +1,25 @@
+package com.springstudy.projectmap.direction.service
+
+import spock.lang.Specification
+
+class Base62ServiceTest extends Specification {
+
+    private Base62Service base62Service;
+
+    def setup() {
+        base62Service = new Base62Service()
+    }
+
+    def "check base62 encoder/decoder"() {
+        given:
+        long num = 5
+
+        when:
+        def encodedId = base62Service.encodeDirectionId(num)
+
+        def decodedId = base62Service.decodeDirectionId(encodedId)
+
+        then:
+        num == decodedId
+    }
+}

--- a/src/test/groovy/com/springstudy/projectmap/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/springstudy/projectmap/direction/service/DirectionServiceTest.groovy
@@ -12,8 +12,9 @@ class DirectionServiceTest extends Specification {
     private PharmacySearchService pharmacySearchService = Mock()
     private DirectionRepository directionRepository = Mock()
     private KakaoCategorySearchService kakaoCategorySearchService = Mock()
+    private Base62Service base62Service = Mock()
 
-    private DirectionService directionService = new DirectionService(pharmacySearchService, directionRepository, kakaoCategorySearchService)
+    private DirectionService directionService = new DirectionService(pharmacySearchService, directionRepository, kakaoCategorySearchService, base62Service)
 
     private List<PharmacyDto> pharmacyList
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,11 @@ spring:
       ddl-auto: create
     show-sql: true
 
+pharmacy:
+  recommendation:
+    base:
+      url: http://localhost:8080/dir/
+
 #kakao:
 #  rest:
 #    api:


### PR DESCRIPTION
카카오 지도 URL을 사용하여 url 구현.
길이가 긴 길안내 url은 `DriectionController`를 거쳐서
shorten url을 제공.
이 때 `Base62`을 사용하여 62진수로 Direction Id 표현.